### PR TITLE
Do not allocate memory inside ops and re-use memory across ops.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -13,10 +13,10 @@ pub fn build(b: *std.Build) void {
     // Standard optimization options allow the person running `zig build` to select
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
     // set a preferred release mode, allowing the user to decide how to optimize.
-    const optimize = b.standardOptimizeOption(.{});
+    const optimize = b.standardOptimizeOption(.{ .preferred_optimize_mode = .ReleaseFast });
 
     const exe = b.addExecutable(.{
-        .name = "nn",
+        .name = "zig_inference",
         // In this case the main source file is merely a path, however, in more
         // complicated build scripts, this could be a generated file.
         .root_source_file = .{ .path = "src/main.zig" },

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -56,8 +56,9 @@ test "Linear" {
 
     // Test Linear with bias.
     const linear = ops.Linear.init(in_features, out_features, weight, bias);
-    const actual = try linear.forward(inputs, allocator);
+    const actual = try allocator.alloc(f32, batch_size * out_features);
     defer allocator.free(actual);
+    linear.forward(inputs, actual);
     try expectTensorsApproxEqual(expected, actual);
 
     // Test Linear no bias.
@@ -70,8 +71,9 @@ test "Linear" {
     defer allocator.free(expected_no_bias);
 
     const no_bias = ops.Linear.init_no_bias(in_features, out_features, weight);
-    const actual_no_bias = try no_bias.forward(inputs, allocator);
+    const actual_no_bias = try allocator.alloc(f32, batch_size * out_features);
     defer allocator.free(actual_no_bias);
+    no_bias.forward(inputs, actual_no_bias);
     try expectTensorsApproxEqual(expected_no_bias, actual_no_bias);
 }
 
@@ -104,8 +106,9 @@ test "Embedding" {
     defer allocator.free(expected);
 
     const embedding = ops.Embedding.init(embedding_dim, weight);
-    const actual = try embedding.forward(inputs, allocator);
+    const actual = try allocator.alloc(f32, batch_size * embedding_dim);
     defer allocator.free(actual);
+    embedding.forward(inputs, actual);
 
     try expectTensorsApproxEqual(expected, actual);
 }
@@ -155,8 +158,7 @@ test "CausalSelfAttention.split_qkv" {
     const batch_size = 3;
     const n_heads = 12;
     const seq_len = 5;
-    const head_dim = 64;
-    const n_embed = n_heads * head_dim;
+    const n_embed = 768;
 
     const allocator = std.heap.page_allocator;
     var inputs = try ops.load_tensor(
@@ -168,33 +170,38 @@ test "CausalSelfAttention.split_qkv" {
     defer allocator.free(inputs);
     var expected_q = try ops.load_tensor(
         "models/test/split_q",
-        &[_]usize{ batch_size, seq_len, n_heads, head_dim },
+        &[_]usize{ batch_size, seq_len, n_embed },
         f32,
         allocator,
     );
     defer allocator.free(expected_q);
     var expected_k = try ops.load_tensor(
         "models/test/split_k",
-        &[_]usize{ batch_size, seq_len, n_heads, head_dim },
+        &[_]usize{ batch_size, seq_len, n_embed },
         f32,
         allocator,
     );
     defer allocator.free(expected_k);
     var expected_v = try ops.load_tensor(
         "models/test/split_v",
-        &[_]usize{ batch_size, seq_len, n_heads, head_dim },
+        &[_]usize{ batch_size, seq_len, n_embed },
         f32,
         allocator,
     );
     defer allocator.free(expected_v);
 
     const fake_attn = ops.CausalSelfAttention.init(n_heads, n_embed, undefined, undefined);
-    const actual_q = try fake_attn.split_qkv(seq_len, inputs, 0, allocator);
-    const actual_k = try fake_attn.split_qkv(seq_len, inputs, 1, allocator);
-    const actual_v = try fake_attn.split_qkv(seq_len, inputs, 2, allocator);
+    const actual_q = try allocator.alloc(f32, batch_size * seq_len * n_embed);
     defer allocator.free(actual_q);
+    fake_attn.split_qkv(seq_len, inputs, 0, actual_q);
+
+    const actual_k = try allocator.alloc(f32, batch_size * seq_len * n_embed);
     defer allocator.free(actual_k);
+    fake_attn.split_qkv(seq_len, inputs, 1, actual_k);
+
+    const actual_v = try allocator.alloc(f32, batch_size * seq_len * n_embed);
     defer allocator.free(actual_v);
+    fake_attn.split_qkv(seq_len, inputs, 2, actual_v);
 
     try expectTensorsApproxEqual(expected_q, actual_q);
     try expectTensorsApproxEqual(expected_k, actual_k);
@@ -205,8 +212,8 @@ test "CausalSelfAttention.transpose" {
     const batch_size = 3;
     const n_heads = 12;
     const seq_len = 5;
-    const head_dim = 64;
-    const n_embed = n_heads * head_dim;
+    const n_embed = 768;
+    const head_dim = n_embed / n_heads;
 
     const allocator = std.heap.page_allocator;
     var inputs = try ops.load_tensor(
@@ -225,8 +232,9 @@ test "CausalSelfAttention.transpose" {
     defer allocator.free(expected);
 
     const fake_attn = ops.CausalSelfAttention.init(n_heads, n_embed, undefined, undefined);
-    const actual = try fake_attn.transpose(seq_len, inputs, allocator);
+    const actual = try allocator.alloc(f32, batch_size * seq_len * n_embed);
     defer allocator.free(actual);
+    fake_attn.transpose(seq_len, inputs, actual);
 
     try expectTensorsApproxEqual(expected, actual);
 }
@@ -235,8 +243,7 @@ test "CausalSelfAttention.forward" {
     const batch_size = 3;
     const n_heads = 12;
     const seq_len = 5;
-    const head_dim = 64;
-    const n_embed = n_heads * head_dim;
+    const n_embed = 768;
 
     const allocator = std.heap.page_allocator;
     var inputs = try ops.load_tensor(
@@ -284,8 +291,21 @@ test "CausalSelfAttention.forward" {
     const c_attn = ops.Linear.init(n_embed, 3 * n_embed, c_attn_weight, c_attn_bias);
     const c_proj = ops.Linear.init(n_embed, n_embed, c_proj_weight, c_proj_bias);
     const attn = ops.CausalSelfAttention.init(n_heads, n_embed, c_attn, c_proj);
-    const actual = try attn.forward(seq_len, inputs, allocator);
+
+    const actual = try allocator.alloc(f32, batch_size * seq_len * n_embed);
     defer allocator.free(actual);
+    const _qkv = try allocator.alloc(f32, batch_size * seq_len * 3 * n_embed);
+    defer allocator.free(_qkv);
+    const _q = try allocator.alloc(f32, batch_size * seq_len * n_embed);
+    defer allocator.free(_q);
+    const _k = try allocator.alloc(f32, batch_size * seq_len * n_embed);
+    defer allocator.free(_k);
+    const _v = try allocator.alloc(f32, batch_size * seq_len * n_embed);
+    defer allocator.free(_v);
+    const _attn = try allocator.alloc(f32, batch_size * n_heads * seq_len * seq_len);
+    defer allocator.free(_attn);
+
+    attn.forward(seq_len, inputs, actual, _qkv, _q, _k, _v, _attn);
 
     try expectTensorsApproxEqual(expected, actual);
 }
@@ -379,16 +399,20 @@ test "scaled_dot_product_attention" {
     );
     defer allocator.free(expected);
 
-    const actual = try ops.scaled_dot_product_attention(
+    const actual = try allocator.alloc(f32, batch_size * seq_len * n_heads * head_dim);
+    defer allocator.free(actual);
+    const _attn = try allocator.alloc(f32, batch_size * n_heads * seq_len * seq_len);
+    defer allocator.free(_attn);
+    ops.scaled_dot_product_attention(
         q,
         k,
         v,
         n_heads,
         seq_len,
         head_dim,
-        allocator,
+        actual,
+        _attn,
     );
-    defer allocator.free(actual);
 
     try expectTensorsApproxEqual(expected, actual);
 }


### PR DESCRIPTION
Surprisingly, this does not actually speed anything up.